### PR TITLE
Change name for carpet boost, added always finish attribute and services to change roomba preferences

### DIFF
--- a/secrets.yaml
+++ b/secrets.yaml
@@ -5,6 +5,7 @@
 # Vacuum
 vacuum_state: http://<ip or fqdn of docker host>:<rest980port>/api/local/info/state
 vacuum_action: http://<ip or fqdn of docker host>:<rest980port>/api/local/action/
+vacuum_config: http://<ip or fqdn of docker host>:<rest980port>/api/local/config/
 vacuum_verify_ssl: false
 vacuum_map: http://<ip or fqdn of docker host>:<nginxphpport>/image.php
 vacuum_log: /config/vacuum/vacuum.log

--- a/vacuum.yaml
+++ b/vacuum.yaml
@@ -163,7 +163,7 @@ sensor:
             {% else %}
               auto
             {% endif %}
-          power_boost: >-
+          carpet_boost: >-
             {% if state_attr('sensor.rest980', 'vacHigh') == 'false' and state_attr('sensor.rest980', 'carpetBoost') == 'false' %}
               eco
             {% elif state_attr('sensor.rest980', 'vacHigh') == 'true' and state_attr('sensor.rest980', 'carpetBoost') == 'false' %}
@@ -173,6 +173,12 @@ sensor:
             {% endif %}
           clean_edges: >-
             {% if state_attr('sensor.rest980', 'openOnly') == 'true' %}
+              false
+            {% else %}
+              true
+            {% endif %}
+          always_finish: >-
+            {% if state_attr('sensor.rest980', 'binPause') == 'true' %}
               false
             {% else %}
               true
@@ -202,6 +208,44 @@ rest_command:
     method: POST
     content_type: 'application/json'
     payload: '{{ payload }}'
+  vacuum_config:
+    url: >-
+      {{ states('input_text.vacuum_config') }}{{ command }}
+    verify_ssl: !secret vacuum_verify_ssl
+    method: POST
+    content_type: 'application/json'
+  vacuum_set_cleaning_passes:
+    url: >-
+      {{ states('input_text.vacuum_config') }}cleaningPasses/{{ passes }}
+    verify_ssl: !secret vacuum_verify_ssl
+    method: POST
+    content_type: 'application/json'
+  vacuum_set_carpet_boost:
+    url: >-
+      {{ states('input_text.vacuum_config') }}carpetBoost/{{ speed }}
+    verify_ssl: !secret vacuum_verify_ssl
+    method: POST
+    content_type: 'application/json'
+  vacuum_toggle_clean_edges:
+    url: >-
+      {% if state_attr('sensor.vacuum', 'clean_edges') == 'true' %}
+        {{ states('input_text.vacuum_config') }}edgeClean/off
+      {% else %}
+        {{ states('input_text.vacuum_config') }}edgeClean/on
+      {% endif %}
+    verify_ssl: !secret vacuum_verify_ssl
+    method: POST
+    content_type: 'application/json'
+  vacuum_toggle_always_finish:
+    url: >-
+      {% if state_attr('sensor.vacuum', 'always_finish') == 'true' %}
+        {{ states('input_text.vacuum_config') }}alwaysFinish/off
+      {% else %}
+        {{ states('input_text.vacuum_config') }}alwaysFinish/on
+      {% endif %}
+    verify_ssl: !secret vacuum_verify_ssl
+    method: POST
+    content_type: 'application/json'
 
 ###################################
 # Input Boolean
@@ -250,6 +294,9 @@ input_text:
   vacuum_action:
     name: Vacuum Action URL
     initial: !secret vacuum_action
+  vacuum_config:
+    name: Vacuum Config URL
+    initial: !secret vacuum_config
   vacuum_map:
     name: Vacuum Map URL
     initial: !secret vacuum_map


### PR DESCRIPTION
I changed the name from "power_boost" to "carpet_boost" to be more compliant with irobot, rest980 and dorita980 nomenclatures.

I added the attribute "always finish" to indicate if paused or not when the bin is full.

I also added several rest_command services to change the cleaning preferences within HA:
- _vacuum_config_: is a general service to change preferences.
- _vacuum_set_cleaning_passes_ and vacuum_set_carpet_boost: are services to change passes and fan speed. Both needs data, i.e. "passes: auto", "speed: eco".
- _vacuum_toggle_clean_edges_ and _vacuum_toggle_always_finish_: As both attributes are binaries, I create a "toggle" service to simplify a litle bit. There's no need for payload data with these services.